### PR TITLE
feat: Replace interfaces with structs 

### DIFF
--- a/base.go
+++ b/base.go
@@ -23,20 +23,18 @@ type buildable interface {
 	init(field reflect.StructField, attrs ...attribute.KeyValue) error
 }
 
-type baseRecord[T n64] interface {
-	Record(ctx context.Context, value T, opts ...metric.RecordOption)
+type RecordFn[T n64] func(ctx context.Context, value T, opts ...metric.RecordOption)
+
+type baseRecord[T n64] struct {
+	Record RecordFn[T]
 }
 
-type baseAdd[T n64] interface {
-	Add(ctx context.Context, n T, opts ...metric.AddOption)
+type baseAdd[T n64] struct {
+	Add AddTFn[T]
 }
+
+type AddTFn[T n64] func(context.Context, T, ...metric.AddOption)
 
 func useFloat[T any]() bool {
 	return reflect.TypeFor[T]().Kind() == reflect.Float64
 }
-
-type dummy[T n64] struct{}
-
-func (d dummy[T]) Record(ctx context.Context, value T, opts ...metric.RecordOption) {}
-
-func (d dummy[T]) Add(ctx context.Context, n T, opts ...metric.AddOption) {}

--- a/consistency/consistency_test.go
+++ b/consistency/consistency_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -41,15 +41,8 @@ type Embedded struct {
 // This test will leverage the project's complete_example.
 // All differentiation can be found there.
 func TestLabelConsistency(t *testing.T) {
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-
-	if filepath.Base(wd) != "consistency" {
-		wd = filepath.Join("consistency")
-	}
 	// sample.txt is the raw payload of the complete_example /metrics endpoint.
-	dataPath := filepath.Join(wd, "raw.txt")
-	data, err := os.ReadFile(dataPath)
+	data, err := os.ReadFile("./raw.txt")
 	require.NoError(t, err)
 
 	ids := getAllIds(t, metrics{})
@@ -136,6 +129,27 @@ func getAllIds(t *testing.T, bases ...any) []string {
 	return res
 }
 
+var genericTypeParameterStripper = regexp.MustCompile(`([^\[]+)\[`)
+
+func isInternalType(t reflect.Type) bool {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.PkgPath() != "github.com/ofeefo/em" {
+		return false
+	}
+	name := t.Name()
+	if !strings.ContainsRune(name, '[') {
+		return false
+	}
+	name = genericTypeParameterStripper.FindStringSubmatch(name)[1]
+	switch name {
+	case "Counter", "Gauge", "UpDownCounter", "Histogram":
+		return true
+	}
+	return false
+}
+
 func getAllIdsOf(t *testing.T, base any) map[string]struct{} {
 	bType := reflect.TypeOf(base)
 	bValue := reflect.ValueOf(base)
@@ -154,9 +168,15 @@ func getAllIdsOf(t *testing.T, base any) map[string]struct{} {
 		field := bType.Field(i)
 		fType := field.Type
 		if fType.Kind() == reflect.Struct || fType.Kind() == reflect.Pointer {
-			innerBase := bValue.Field(i)
-			if reflect.Indirect(innerBase).Kind() == reflect.Ptr {
+			var innerBase reflect.Value
+			if field.Type.Kind() == reflect.Ptr {
 				innerBase = reflect.New(field.Type.Elem())
+			} else {
+				innerBase = bValue.Field(i)
+			}
+
+			if isInternalType(fType) {
+				continue
 			}
 
 			innerIds := getAllIdsOf(t, innerBase.Interface())
@@ -167,7 +187,7 @@ func getAllIdsOf(t *testing.T, base any) map[string]struct{} {
 		}
 
 		id, ok := field.Tag.Lookup("id")
-		require.True(t, ok)
+		require.True(t, ok, "id tag not found on field %s: %s", field.Name, bType.Name())
 		// prometheus registers counters with a name prefixed with '_total'.
 		// UpDown counters for the test were registered with ids suffixed by
 		// '_updowncounters' so we can easily separate them here

--- a/counter.go
+++ b/counter.go
@@ -11,69 +11,58 @@ import (
 // Counter is a synchronous Instrument which supports non-negative increments.
 // Complete docs:
 // https://opentelemetry.io/docs/specs/otel/metrics/api/#counter
-type Counter[T n64] interface {
-	// Add records a change of n to the counter.
-	Add(n T, opts ...metric.AddOption)
-
-	// AddCtx records a change of n to the counter.
-	AddCtx(ctx context.Context, n T, opts ...metric.AddOption)
-
-	// Inc records a change of 1 to the counter.
-	Inc(opts ...metric.AddOption)
-
-	// IncCtx records a change of 1 to the counter.
-	IncCtx(ctx context.Context, opts ...metric.AddOption)
-}
-
-type counter[T n64] struct {
+type Counter[T n64] struct {
 	attrs []attribute.KeyValue
 	baseAdd[T]
 }
 
-func (c *counter[T]) Add(n T, opts ...metric.AddOption) {
+// Add records a change of n to the counter.
+func (c *Counter[T]) Add(n T, opts ...metric.AddOption) {
 	c.AddCtx(context.Background(), n, opts...)
 }
 
-func (c *counter[T]) AddCtx(ctx context.Context, n T, opts ...metric.AddOption) {
+// AddCtx records a change of n to the counter.
+func (c *Counter[T]) AddCtx(ctx context.Context, n T, opts ...metric.AddOption) {
+	if c.baseAdd.Add == nil {
+		return
+	}
 	c.baseAdd.Add(ctx, n, append(opts, metric.WithAttributes(c.attrs...))...)
 }
 
-func (c *counter[T]) Inc(opts ...metric.AddOption) {
+// Inc records a change of 1 to the counter.
+func (c *Counter[T]) Inc(opts ...metric.AddOption) {
 	c.AddCtx(context.Background(), 1, opts...)
 }
 
-func (c *counter[T]) IncCtx(ctx context.Context, opts ...metric.AddOption) {
+// IncCtx records a change of 1 to the counter.
+func (c *Counter[T]) IncCtx(ctx context.Context, opts ...metric.AddOption) {
 	c.AddCtx(ctx, 1, opts...)
 }
 
-func newCounter[T n64]() buildable { return new(counter[T]) }
-
-func (c *counter[T]) init(field reflect.StructField, attrs ...attribute.KeyValue) error {
-	if p == nil {
-		c.baseAdd = dummy[T]{}
-		return nil
-	}
-
-	var (
-		base any
-		err  error
-	)
-
+func (c *Counter[T]) init(field reflect.StructField, attrs ...attribute.KeyValue) error {
 	id, err := getID(field)
 	if err != nil {
 		return err
 	}
+	c.attrs = attrs
 
 	if useFloat[T]() {
-		base, err = p.m.Float64Counter(id)
+		base, err := p.m.Float64Counter(id)
+		if err != nil {
+			return err
+		}
+		c.baseAdd.Add = func(ctx context.Context, t T, option ...metric.AddOption) {
+			base.Add(ctx, float64(t), append(option, metric.WithAttributes(c.attrs...))...)
+		}
 	} else {
-		base, err = p.m.Int64Counter(id)
-	}
-	if err != nil {
-		return err
+		base, err := p.m.Int64Counter(id)
+		if err != nil {
+			return err
+		}
+		c.baseAdd.Add = func(ctx context.Context, t T, option ...metric.AddOption) {
+			base.Add(ctx, int64(t), append(option, metric.WithAttributes(c.attrs...))...)
+		}
 	}
 
-	c.baseAdd = base.(baseAdd[T])
-	c.attrs = attrs
 	return nil
 }

--- a/example/complete_usage/main.go
+++ b/example/complete_usage/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel/attribute"
 
-	em "github.com/ofeefo/em"
+	"github.com/ofeefo/em"
 )
 
 type metrics struct {

--- a/example/simple_usage/main.go
+++ b/example/simple_usage/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel/attribute"
 
-	em "github.com/ofeefo/em"
+	"github.com/ofeefo/em"
 )
 
 // Define your metrics

--- a/gauge.go
+++ b/gauge.go
@@ -11,57 +11,49 @@ import (
 // Gauge is a synchronous Instrument which can be used to record non-additive
 // value(s).
 // Complete docs: https://opentelemetry.io/docs/specs/otel/metrics/api/#gauge
-type Gauge[T n64] interface {
-	// Record records the value of n to the gauge.
-	Record(n T, opts ...metric.RecordOption)
-
-	// RecordCtx records the value of n to the gauge.
-	RecordCtx(ctx context.Context, n T, opts ...metric.RecordOption)
-}
-
-type gauge[T n64] struct {
+type Gauge[T n64] struct {
 	attrs []attribute.KeyValue
 	baseRecord[T]
 }
 
-func (g *gauge[T]) Record(n T, opts ...metric.RecordOption) {
+// Record records the value of n to the gauge.
+func (g *Gauge[T]) Record(n T, opts ...metric.RecordOption) {
 	g.RecordCtx(context.Background(), n, opts...)
 }
 
-func (g *gauge[T]) RecordCtx(ctx context.Context, n T, opts ...metric.RecordOption) {
+// RecordCtx records the value of n to the gauge.
+func (g *Gauge[T]) RecordCtx(ctx context.Context, n T, opts ...metric.RecordOption) {
+	if g.baseRecord.Record == nil {
+		return
+	}
 	g.baseRecord.Record(ctx, n, append(opts, metric.WithAttributes(g.attrs...))...)
 }
 
-func newGauge[T n64]() buildable { return new(gauge[T]) }
-
-func (g *gauge[T]) init(field reflect.StructField, attrs ...attribute.KeyValue) error {
-	if p == nil {
-		g.baseRecord = dummy[T]{}
-		return nil
-	}
-
-	var (
-		base any
-		err  error
-	)
+func (g *Gauge[T]) init(field reflect.StructField, attrs ...attribute.KeyValue) error {
 
 	id, err := getID(field)
 	if err != nil {
 		return err
 	}
+	g.attrs = attrs
 
 	if useFloat[T]() {
-		base, err = p.m.Float64Gauge(id)
+		base, err := p.m.Float64Gauge(id)
+		if err != nil {
+			return err
+		}
+		g.baseRecord.Record = func(ctx context.Context, value T, opts ...metric.RecordOption) {
+			base.Record(ctx, float64(value), append(opts, metric.WithAttributes(g.attrs...))...)
+		}
 	} else {
-		base, err = p.m.Int64Gauge(id)
+		base, err := p.m.Int64Gauge(id)
+		if err != nil {
+			return err
+		}
+		g.baseRecord.Record = func(ctx context.Context, value T, opts ...metric.RecordOption) {
+			base.Record(ctx, int64(value), append(opts, metric.WithAttributes(g.attrs...))...)
+		}
 	}
-
-	if err != nil {
-		return err
-	}
-
-	g.baseRecord = base.(baseRecord[T])
-	g.attrs = attrs
 
 	return nil
 }

--- a/histogram.go
+++ b/histogram.go
@@ -14,44 +14,37 @@ import (
 // statistics such as histograms, summaries, and percentile.
 // Complete docs:
 // https://opentelemetry.io/docs/specs/otel/metrics/api/#histogram
-type Histogram[T n64] interface {
-	// Record adds a value to the distribution.
-	Record(n T, opts ...metric.RecordOption)
-
-	// RecordCtx adds a value to the distribution.
-	RecordCtx(ctx context.Context, n T, opts ...metric.RecordOption)
-
-	// Measure creates a starting point using time.Now and returns a function
-	// that records the time elapsed since the starting point. The returned
-	// function may also receive record options to further support information
-	// that may vary along a given procedure.
-	Measure(sub timeSub[T], opts ...metric.RecordOption) func(opts ...metric.RecordOption)
-
-	// MeasureCtx creates a starting point using time.Now and returns a function
-	// that records the time elapsed since the starting point. The returned
-	// function may also receive record options to further support information
-	// that may vary along a given procedure.
-	MeasureCtx(ctx context.Context, sub timeSub[T], opts ...metric.RecordOption) func(opts ...metric.RecordOption)
-}
-
-type histogram[T n64] struct {
+type Histogram[T n64] struct {
 	attrs []attribute.KeyValue
 	baseRecord[T]
 }
 
-func (h *histogram[T]) Record(n T, opts ...metric.RecordOption) {
+// Record adds a value to the distribution.
+func (h *Histogram[T]) Record(n T, opts ...metric.RecordOption) {
 	h.RecordCtx(context.Background(), n, opts...)
 }
 
-func (h *histogram[T]) RecordCtx(ctx context.Context, n T, opts ...metric.RecordOption) {
+// RecordCtx adds a value to the distribution.
+func (h *Histogram[T]) RecordCtx(ctx context.Context, n T, opts ...metric.RecordOption) {
+	if h.baseRecord.Record == nil {
+		return
+	}
 	h.baseRecord.Record(ctx, n, append(opts, metric.WithAttributes(h.attrs...))...)
 }
 
-func (h *histogram[T]) Measure(sub timeSub[T], opts ...metric.RecordOption) func(opts ...metric.RecordOption) {
+// Measure creates a starting point using time.Now and returns a function
+// that records the time elapsed since the starting point. The returned
+// function may also receive record options to further support information
+// that may vary along a given procedure.
+func (h *Histogram[T]) Measure(sub timeSub[T], opts ...metric.RecordOption) func(opts ...metric.RecordOption) {
 	return h.MeasureCtx(context.Background(), sub, opts...)
 }
 
-func (h *histogram[T]) MeasureCtx(ctx context.Context, sub timeSub[T], opts ...metric.RecordOption) func(opts ...metric.RecordOption) {
+// MeasureCtx creates a starting point using time.Now and returns a function
+// that records the time elapsed since the starting point. The returned
+// function may also receive record options to further support information
+// that may vary along a given procedure.
+func (h *Histogram[T]) MeasureCtx(ctx context.Context, sub timeSub[T], opts ...metric.RecordOption) func(opts ...metric.RecordOption) {
 	start := time.Now()
 	baseOpts := opts
 	return func(opts ...metric.RecordOption) {
@@ -59,22 +52,13 @@ func (h *histogram[T]) MeasureCtx(ctx context.Context, sub timeSub[T], opts ...m
 	}
 }
 
-func newHistogram[T n64]() buildable { return new(histogram[T]) }
-
-func (h *histogram[T]) init(field reflect.StructField, attrs ...attribute.KeyValue) error {
-	if p == nil {
-		h.baseRecord = dummy[T]{}
-		return nil
-	}
-
-	var (
-		base any
-		err  error
-	)
+func (h *Histogram[T]) init(field reflect.StructField, attrs ...attribute.KeyValue) error {
 	id, err := getID(field)
 	if err != nil {
 		return err
 	}
+
+	h.attrs = attrs
 
 	bounds, err := getBounds(field)
 	if err != nil {
@@ -82,16 +66,22 @@ func (h *histogram[T]) init(field reflect.StructField, attrs ...attribute.KeyVal
 	}
 
 	if useFloat[T]() {
-		base, err = p.m.Float64Histogram(id, metric.WithExplicitBucketBoundaries(bounds...))
+		base, err := p.m.Float64Histogram(id, metric.WithExplicitBucketBoundaries(bounds...))
+		if err != nil {
+			return err
+		}
+		h.baseRecord.Record = func(ctx context.Context, value T, opts ...metric.RecordOption) {
+			base.Record(ctx, float64(value), append(opts, metric.WithAttributes(h.attrs...))...)
+		}
 	} else {
-		base, err = p.m.Int64Histogram(id, metric.WithExplicitBucketBoundaries(bounds...))
+		base, err := p.m.Int64Histogram(id, metric.WithExplicitBucketBoundaries(bounds...))
+		if err != nil {
+			return err
+		}
+		h.baseRecord.Record = func(ctx context.Context, value T, opts ...metric.RecordOption) {
+			base.Record(ctx, int64(value), append(opts, metric.WithAttributes(h.attrs...))...)
+		}
 	}
 
-	if err != nil {
-		return err
-	}
-
-	h.baseRecord = base.(baseRecord[T])
-	h.attrs = attrs
 	return nil
 }

--- a/initializer.go
+++ b/initializer.go
@@ -3,26 +3,9 @@ package em
 import (
 	"fmt"
 	"reflect"
-	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
 )
-
-var bmMu = &sync.Mutex{}
-
-var bmap = map[reflect.Type]func() buildable{
-	reflect.TypeFor[Gauge[int64]]():   newGauge[int64],
-	reflect.TypeFor[Gauge[float64]](): newGauge[float64],
-
-	reflect.TypeFor[Counter[int64]]():   newCounter[int64],
-	reflect.TypeFor[Counter[float64]](): newCounter[float64],
-
-	reflect.TypeFor[Histogram[int64]]():   newHistogram[int64],
-	reflect.TypeFor[Histogram[float64]](): newHistogram[float64],
-
-	reflect.TypeFor[UpDownCounter[int64]]():   newUpDownCounter[int64],
-	reflect.TypeFor[UpDownCounter[float64]](): newUpDownCounter[float64],
-}
 
 func MustInit[T any](attrs ...attribute.KeyValue) *T {
 	res, err := Init[T](attrs...)
@@ -59,25 +42,32 @@ func initRef(base any, attrs ...attribute.KeyValue) error {
 		if !field.IsExported() {
 			continue
 		}
-		bmMu.Lock()
-		fn, ok := bmap[field.Type]
-		bmMu.Unlock()
-		n := reflect.New(field.Type)
+
+		fieldIface := fieldVal.Interface()
+		builder, ok := fieldIface.(buildable)
+
 		switch {
 		case ok:
-			builder := fn()
 			if err := builder.init(field, attrs...); err != nil {
 				return err
 			}
 			fieldVal.Set(reflect.ValueOf(builder))
 
-		case n.Elem().Kind() == reflect.Struct:
-			if err := initNested(field, n, fieldVal, attrs...); err != nil {
-				return err
+		case fieldVal.Kind() == reflect.Struct:
+			if fieldVal.CanAddr() {
+				p := fieldVal.Addr()
+				if err := initNested(field, p, fieldVal, attrs...); err != nil {
+					return err
+				}
+			} else {
+				p := reflect.New(fieldVal.Type())
+				if err := initNested(field, p, fieldVal, attrs...); err != nil {
+					return err
+				}
 			}
 
-		case n.Elem().Kind() == reflect.Ptr:
-			n = reflect.New(field.Type.Elem())
+		case fieldVal.Kind() == reflect.Ptr:
+			n := reflect.New(field.Type.Elem())
 			if err := initNested(field, n, fieldVal, attrs...); err != nil {
 				return err
 			}

--- a/record.go
+++ b/record.go
@@ -1,1 +1,0 @@
-package em

--- a/updown_counter.go
+++ b/updown_counter.go
@@ -11,84 +11,68 @@ import (
 // UpDownCounter is a synchronous Instrument which supports increments and decrements.
 // Complete docs:
 // https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter
-type UpDownCounter[T n64] interface {
-	// Add records a change of n to the counter.
-	Add(n T, opts ...metric.AddOption)
-
-	// AddCtx records a change of n to the counter.
-	AddCtx(ctx context.Context, n T, opts ...metric.AddOption)
-
-	// Inc records a change of 1 to the counter.
-	Inc(opts ...metric.AddOption)
-
-	// IncCtx records a change of 1 to the counter.
-	IncCtx(ctx context.Context, opts ...metric.AddOption)
-
-	// Dec records a change of -1 to the counter.
-	Dec(opts ...metric.AddOption)
-
-	// DecCtx records a change of -1 to the counter.
-	DecCtx(ctx context.Context, opts ...metric.AddOption)
-}
-
-type upDownCounter[T n64] struct {
+type UpDownCounter[T n64] struct {
 	attrs []attribute.KeyValue
 	baseAdd[T]
 }
 
-func (u *upDownCounter[T]) Add(n T, opts ...metric.AddOption) {
+// Add records a change of n to the counter.
+func (u *UpDownCounter[T]) Add(n T, opts ...metric.AddOption) {
 	u.AddCtx(context.Background(), n, opts...)
 }
 
-func (u *upDownCounter[T]) AddCtx(ctx context.Context, n T, opts ...metric.AddOption) {
+// AddCtx records a change of n to the counter.
+func (u *UpDownCounter[T]) AddCtx(ctx context.Context, n T, opts ...metric.AddOption) {
+	if u.baseAdd.Add == nil {
+		return
+	}
 	u.baseAdd.Add(ctx, n, append(opts, metric.WithAttributes(u.attrs...))...)
 }
 
-func (u *upDownCounter[T]) Inc(opts ...metric.AddOption) {
+// Inc records a change of 1 to the counter.
+func (u *UpDownCounter[T]) Inc(opts ...metric.AddOption) {
 	u.AddCtx(context.Background(), 1, opts...)
 }
 
-func (u *upDownCounter[T]) IncCtx(ctx context.Context, opts ...metric.AddOption) {
+// IncCtx records a change of 1 to the counter.
+func (u *UpDownCounter[T]) IncCtx(ctx context.Context, opts ...metric.AddOption) {
 	u.AddCtx(ctx, 1, opts...)
 }
 
-func (u *upDownCounter[T]) Dec(opts ...metric.AddOption) {
+// Dec records a change of -1 to the counter.
+func (u *UpDownCounter[T]) Dec(opts ...metric.AddOption) {
 	u.AddCtx(context.Background(), -1, opts...)
 }
 
-func (u *upDownCounter[T]) DecCtx(ctx context.Context, opts ...metric.AddOption) {
+// DecCtx records a change of -1 to the counter.
+func (u *UpDownCounter[T]) DecCtx(ctx context.Context, opts ...metric.AddOption) {
 	u.AddCtx(ctx, 1, opts...)
 }
 
-func newUpDownCounter[T n64]() buildable { return new(upDownCounter[T]) }
-
-func (u *upDownCounter[T]) init(field reflect.StructField, attrs ...attribute.KeyValue) error {
-	if p == nil {
-		u.baseAdd = dummy[T]{}
-		return nil
-	}
-
-	var (
-		base any
-		err  error
-	)
-
+func (u *UpDownCounter[T]) init(field reflect.StructField, attrs ...attribute.KeyValue) error {
 	id, err := getID(field)
 	if err != nil {
 		return err
 	}
+	u.attrs = attrs
 
 	if useFloat[T]() {
-		base, err = p.m.Float64UpDownCounter(id)
+		base, err := p.m.Float64UpDownCounter(id)
+		if err != nil {
+			return err
+		}
+		u.baseAdd.Add = func(ctx context.Context, t T, option ...metric.AddOption) {
+			base.Add(ctx, float64(t), append(option, metric.WithAttributes(u.attrs...))...)
+		}
 	} else {
-		base, err = p.m.Int64UpDownCounter(id)
+		base, err := p.m.Int64UpDownCounter(id)
+		if err != nil {
+			return err
+		}
+		u.baseAdd.Add = func(ctx context.Context, t T, option ...metric.AddOption) {
+			base.Add(ctx, int64(t), append(option, metric.WithAttributes(u.attrs...))...)
+		}
 	}
 
-	if err != nil {
-		return err
-	}
-
-	u.baseAdd = base.(baseAdd[T])
-	u.attrs = attrs
 	return nil
 }

--- a/usage_test.go
+++ b/usage_test.go
@@ -1,0 +1,39 @@
+package em
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type UninitializedSubMetrics struct {
+	CounterB Counter[int64] `id:"counter_b"`
+}
+
+type UninitializedMetrics struct {
+	Counter Counter[int64] `id:"counter"`
+	Sub     UninitializedSubMetrics
+}
+
+func TestInitialized(t *testing.T) {
+	m, err := Init[UninitializedMetrics]()
+	require.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		m.Counter.Inc()
+	})
+	assert.NotPanics(t, func() {
+		m.Sub.CounterB.Inc()
+	})
+}
+
+func TestUninitialized(t *testing.T) {
+	m := UninitializedMetrics{}
+	assert.NotPanics(t, func() {
+		m.Counter.Inc()
+	})
+	assert.NotPanics(t, func() {
+		m.Sub.CounterB.Inc()
+	})
+}


### PR DESCRIPTION
This pull request refactors the metric instrument types (`Counter`, `Gauge`, `Histogram`, `UpDownCounter`) from interfaces to structs with function fields, simplifying initialization and usage. It removes unnecessary indirection and dummy implementations, improves the initialization logic, and enhances testability and robustness. Additionally, several test and import improvements are made for clarity and reliability.

### Refactoring metric instrument types

* Changed `Counter`, `Gauge`, `Histogram`, and `UpDownCounter` from interfaces to structs with function fields, eliminating the need for dummy implementations and simplifying method calls. (`counter.go`, `gauge.go`, `histogram.go`, `updown_counter.go`, `base.go`) [[1]](diffhunk://#diff-8571a7cc38c60d2daf90c7bb86107cf53d8bed481ee08678d1b37a736a8ab1acL14-L77) [[2]](diffhunk://#diff-f8b74f9add024a6d319345e7d127b7ebf8d3b690b9d5b8aebc4586d3e2840820L14-R56) [[3]](diffhunk://#diff-5eb789b20e2d1d5c69ad053068b472ba04c082d064efa7bf1ae6e1a6b54394c0L17-L95) [[4]](diffhunk://#diff-fd161c200712a8cb1c56c6999d7b1dff89c87b8f07621137510c5cc02e7de418L14-L92) [[5]](diffhunk://#diff-70f1ecb7be66d191151d77019a75ef0ba0404acdcbaf1aa630099ed46d208771L26-L42)
* Updated initialization logic to set function fields directly, and added nil checks to prevent panics when methods are called on uninitialized metrics. (`counter.go`, `gauge.go`, `histogram.go`, `updown_counter.go`) [[1]](diffhunk://#diff-8571a7cc38c60d2daf90c7bb86107cf53d8bed481ee08678d1b37a736a8ab1acL14-L77) [[2]](diffhunk://#diff-f8b74f9add024a6d319345e7d127b7ebf8d3b690b9d5b8aebc4586d3e2840820L14-R56) [[3]](diffhunk://#diff-5eb789b20e2d1d5c69ad053068b472ba04c082d064efa7bf1ae6e1a6b54394c0L17-L95) [[4]](diffhunk://#diff-fd161c200712a8cb1c56c6999d7b1dff89c87b8f07621137510c5cc02e7de418L14-L92)

### Initialization and builder logic

* Removed the `bmap` builder map and refactored initialization to use type assertions for `buildable` interfaces, improving extensibility and reducing complexity. (`initializer.go`, `base.go`) [[1]](diffhunk://#diff-71391ade91f807013369480916c5ba20eea825c0bdb67273088ae321a09f1f30L13-L26) [[2]](diffhunk://#diff-71391ade91f807013369480916c5ba20eea825c0bdb67273088ae321a09f1f30L62-R73) [[3]](diffhunk://#diff-70f1ecb7be66d191151d77019a75ef0ba0404acdcbaf1aa630099ed46d208771L26-L42)
* Improved nested struct initialization handling to support both addressable and non-addressable fields. (`initializer.go`)

### Testing improvements

* Added `usage_test.go` to verify that calling metric methods on both initialized and uninitialized structs does not panic, increasing confidence in safe usage. (`usage_test.go`)
* Enhanced consistency tests to simplify file path handling and improve error messages when `id` tags are missing. (`consistency/consistency_test.go`) [[1]](diffhunk://#diff-01887d0d44fe29b39909b9cefbc8b5dbf49166040ca83a795e45f3a6259ac47cL44-R45) [[2]](diffhunk://#diff-01887d0d44fe29b39909b9cefbc8b5dbf49166040ca83a795e45f3a6259ac47cL170-R190)

### Miscellaneous improvements

* Improved import statements for clarity and consistency. (`example/complete_usage/main.go`, `example/simple_usage/main.go`) [[1]](diffhunk://#diff-42feda3c1dc81ec23d98eaf34a884b7aad309ff0cf35e77cc86ea19eb5e74dd8L10-R10) [[2]](diffhunk://#diff-9a60ed8c155181f3591522a9bbf0f1630b38699e7d41a8b612b3a488ff6006e6L10-R10)
* Added logic to filter out internal types in test helpers for more accurate test coverage. (`consistency/consistency_test.go`) [[1]](diffhunk://#diff-01887d0d44fe29b39909b9cefbc8b5dbf49166040ca83a795e45f3a6259ac47cR132-R152) [[2]](diffhunk://#diff-01887d0d44fe29b39909b9cefbc8b5dbf49166040ca83a795e45f3a6259ac47cL157-R179)

### Cleanup

* Removed empty file `record.go`.