### PR TITLE
feat: Prevent Init without Setup

### DIFF
--- a/consistency/consistency_test.go
+++ b/consistency/consistency_test.go
@@ -12,6 +12,7 @@ import (
 	ioprometheusclient "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/ofeefo/em"
 )
@@ -44,8 +45,11 @@ func TestLabelConsistency(t *testing.T) {
 	// sample.txt is the raw payload of the complete_example /metrics endpoint.
 	data, err := os.ReadFile("./raw.txt")
 	require.NoError(t, err)
+	em.SetupWithMeter(noop.Meter{})
+	obj, err := em.Init[metrics]()
+	require.NoError(t, err)
 
-	ids := getAllIds(t, metrics{})
+	ids := getAllIds(t, obj)
 
 	p := &expfmt.TextParser{}
 	mfs, err := p.TextToMetricFamilies(bytes.NewBuffer(data))

--- a/initializer.go
+++ b/initializer.go
@@ -16,6 +16,9 @@ func MustInit[T any](attrs ...attribute.KeyValue) *T {
 }
 
 func Init[T any](attrs ...attribute.KeyValue) (*T, error) {
+	if !p.ready {
+		return nil, fmt.Errorf("em.Init called before em.Setup")
+	}
 	base := new(T)
 	if err := initRef(base, attrs...); err != nil {
 		return nil, err
@@ -43,7 +46,12 @@ func initRef(base any, attrs ...attribute.KeyValue) error {
 			continue
 		}
 
-		fieldIface := fieldVal.Interface()
+		var fieldIface any
+		if fieldVal.Type().Kind() == reflect.Ptr {
+			fieldIface = reflect.New(fieldVal.Type().Elem()).Interface()
+		} else {
+			fieldIface = fieldVal.Addr().Interface()
+		}
 		builder, ok := fieldIface.(buildable)
 
 		switch {
@@ -51,7 +59,11 @@ func initRef(base any, attrs ...attribute.KeyValue) error {
 			if err := builder.init(field, attrs...); err != nil {
 				return err
 			}
-			fieldVal.Set(reflect.ValueOf(builder))
+			if fieldVal.Kind() == reflect.Ptr {
+				fieldVal.Set(reflect.ValueOf(builder))
+			} else {
+				fieldVal.Set(reflect.ValueOf(builder).Elem())
+			}
 
 		case fieldVal.Kind() == reflect.Struct:
 			if fieldVal.CanAddr() {
@@ -71,6 +83,7 @@ func initRef(base any, attrs ...attribute.KeyValue) error {
 			if err := initNested(field, n, fieldVal, attrs...); err != nil {
 				return err
 			}
+			fieldVal.Set(n)
 		}
 	}
 	return nil

--- a/initializer_test.go
+++ b/initializer_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 type metrics struct {
@@ -24,6 +25,7 @@ type nested struct {
 		Counter Counter[float64] `id:"example_more_nested_counter"`
 	}
 }
+
 type Embedded struct {
 	Histogram     Histogram[int64]     `id:"example_embedded_histogram"`
 	UpDownCounter UpDownCounter[int64] `id:"example_embedded_updowncounter"`
@@ -50,6 +52,7 @@ func mustSetup(t *testing.T, attrs ...attribute.KeyValue) {
 func initAndCall(t *testing.T) func() {
 	t.Helper()
 	return func() {
+		SetupWithMeter(noop.Meter{})
 		var m *metrics
 		require.NotPanics(t, func() { m = MustInit[metrics]() })
 		require.NotPanics(t, func() {

--- a/provider.go
+++ b/provider.go
@@ -1,19 +1,26 @@
 package em
 
 import (
+	"sync"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 	m2 "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 type provider struct {
-	m metric.Meter
+	m     metric.Meter
+	ready bool
+	mu    sync.Mutex
 }
 
-var p *provider = nil
+var p = &provider{
+	m: noop.Meter{},
+}
 
 func MustSetup(name string, attrs ...attribute.KeyValue) {
 	if err := Setup(name, attrs...); err != nil {
@@ -22,15 +29,18 @@ func MustSetup(name string, attrs ...attribute.KeyValue) {
 }
 
 func SetupWithMeter(meter metric.Meter) {
-	if p != nil {
-		p.m = meter
-	} else {
-		p = &provider{m: meter}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if meter == nil {
+		panic("nil meter provided to SetupWithMeter")
 	}
+	p = &provider{m: meter, ready: true}
 }
 
 func Setup(name string, attrs ...attribute.KeyValue) error {
-	if p != nil {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.ready {
 		return nil
 	}
 
@@ -41,6 +51,7 @@ func Setup(name string, attrs ...attribute.KeyValue) error {
 
 	res := resource.NewWithAttributes(semconv.SchemaURL, attrs...)
 	exp := m2.NewMeterProvider(m2.WithReader(promEx), m2.WithResource(res))
-	p = &provider{m: exp.Meter(name)}
+	p.m = exp.Meter(name)
+	p.ready = true
 	return nil
 }


### PR DESCRIPTION
This pull request introduces several improvements to the initialization and setup logic for the metrics provider, focusing on safer setup, thread safety, and more robust error handling. The most significant changes include enforcing provider readiness before initialization, making the provider thread-safe, and updating test and example usage to use the noop meter.

### Provider setup and safety improvements

* Added a `ready` flag and a mutex to the `provider` struct to ensure thread-safe setup and prevent usage before initialization. The global provider now starts with a noop meter by default. (`provider.go`)
* The `SetupWithMeter` and `Setup` functions now use locking and check readiness, preventing double initialization and panicking if a nil meter is provided. (`provider.go`)
* The provider's meter is now updated in-place, and the `ready` flag is set after successful setup, ensuring safe access. (`provider.go`)

### Initialization error handling

* The `Init` function now checks the provider's readiness and returns an error if called before setup, preventing accidental usage before proper initialization. (`initializer.go`)

### Test and example updates

* Updated tests and examples to explicitly call `SetupWithMeter(noop.Meter{})` before initialization, ensuring consistent test behavior and readiness. (`consistency_test.go`, `initializer_test.go`) [[1]](diffhunk://#diff-01887d0d44fe29b39909b9cefbc8b5dbf49166040ca83a795e45f3a6259ac47cR15) [[2]](diffhunk://#diff-01887d0d44fe29b39909b9cefbc8b5dbf49166040ca83a795e45f3a6259ac47cR48-R52) [[3]](diffhunk://#diff-803845d597f96db3e965a8b6c00ccf0f90695a73cd68feedbabd7405aae05674R9) [[4]](diffhunk://#diff-803845d597f96db3e965a8b6c00ccf0f90695a73cd68feedbabd7405aae05674R55)

### Reflection-based initialization fixes

* Improved the reflection logic in `initRef` to handle pointer and non-pointer fields correctly, ensuring proper initialization of nested and embedded metric structs. (`initializer.go`) [[1]](diffhunk://#diff-71391ade91f807013369480916c5ba20eea825c0bdb67273088ae321a09f1f30L46-R66) [[2]](diffhunk://#diff-71391ade91f807013369480916c5ba20eea825c0bdb67273088ae321a09f1f30R86)